### PR TITLE
Refines 03.09.24 - Part 2

### DIFF
--- a/Sources/CoreColor/Color.swift
+++ b/Sources/CoreColor/Color.swift
@@ -18,8 +18,11 @@ public protocol Color {
     /// Retrieves the associated color space of the model.
     var space: AssociatedColorSpace { get }
 
-    /// Converts to the equivalent RGB color model in sRGB color space.
+    /// Converts to the equivalent RGB color model in sRGB (``RGBColorSpaces.sRGB``) color space.
     func toSRGB() -> RGB
+
+    /// Converts to the equivalent RGB color model in Linear sRGB  (``RGBColorSpaces.LinearSRGB``) color space.
+    func toLinearSRGB() -> RGB
 
     /// Converts to the equivalent HSL color model.
     func toHSL() -> HSL
@@ -47,6 +50,10 @@ public protocol Color {
 }
 
 extension Color {
+
+    public func toLinearSRGB() -> RGB {
+        self.toSRGB().toLinearSRGB()
+    }
 
     public func toHSL() -> HSL {
         self.toSRGB().toHSL()

--- a/Sources/CoreColor/Models/RGB.swift
+++ b/Sources/CoreColor/Models/RGB.swift
@@ -27,7 +27,7 @@ public struct RGB: Color {
 
     public let space: RGBColorSpace
 
-    init(
+    public init(
         @Clamped(range: 0.0...1.0) r: Float,
         @Clamped(range: 0.0...1.0) g: Float,
         @Clamped(range: 0.0...1.0) b: Float,
@@ -146,7 +146,9 @@ extension RGB {
 
         let v = self.space.matrixToXyz * simd_float3(f(self.r), f(self.g), f(self.b))
 
-        return XYZ(x: v.x, y: v.y, z: v.z, alpha: self.alpha, space: XYZColorSpace(whitePoint: self.space.whitePoint))
+        let space = XYZColorSpace(whitePoint: self.space.whitePoint)
+
+        return XYZ(x: v.x, y: v.y, z: v.z, alpha: self.alpha, space: space)
     }
 
     public func toCMYK() -> CMYK {
@@ -169,7 +171,9 @@ extension RGB {
     ///
     /// Min and max are scaled to [0, 1].
     ///
-    func srgbHueMinMaxChroma<T>(_ block: (_ hue: Double, _ min: Double, _ max: Double, _ chroma: Double) -> T) -> T {
+    func srgbHueMinMaxChroma<T>(
+        _ block: (_ hue: Double, _ min: Double, _ max: Double, _ chroma: Double) -> T
+    ) -> T {
         let rD: Double = Double(self.r)
         let gD: Double = Double(self.g)
         let bD: Double = Double(self.b)

--- a/Sources/CoreColor/Models/RGB.swift
+++ b/Sources/CoreColor/Models/RGB.swift
@@ -96,20 +96,20 @@ public struct RGB: Color {
         Int(alpha * 255)
     }
 
-    public func toSRGB() -> RGB {
-        self.convert(toRGBColorSpace: RGBColorSpaces.sRGB)
-    }
-
-    public func toRGB() -> RGB {
-        self.convert(toRGBColorSpace: RGBColorSpaces.LinearSRGB)
-    }
-
     public static func from(color: any Color) -> Self {
         color.toSRGB()
     }
 }
 
 extension RGB {
+
+    public func toSRGB() -> RGB {
+        self.convert(toRGBColorSpace: RGBColorSpaces.sRGB)
+    }
+
+    public func toLinearSRGB() -> RGB {
+        self.convert(toRGBColorSpace: RGBColorSpaces.LinearSRGB)
+    }
 
     public func toHSL() -> HSL {
         srgbHueMinMaxChroma { (h, mn, mx, chroma) -> HSL in

--- a/Sources/CoreColor/Models/XYZ.swift
+++ b/Sources/CoreColor/Models/XYZ.swift
@@ -168,6 +168,14 @@ public struct XYZ: Color {
 
 extension XYZ {
 
+    public func sRGB() -> RGB {
+        to(rgbSpace: RGBColorSpaces.sRGB)
+    }
+
+    public func toLinearSRGB() -> RGB {
+        to(rgbSpace: RGBColorSpaces.LinearSRGB)
+    }
+
     public func toLAB() -> LAB {
         func f(_ t: Float) -> Float {
             t > CIE_E ? (cbrt(t)) : ((t * CIE_K + 16) / 116)

--- a/Sources/CoreColor/Models/XYZ.swift
+++ b/Sources/CoreColor/Models/XYZ.swift
@@ -29,18 +29,28 @@ fileprivate let CAT02_LMS_TO_XYZ = CAT02_XYZ_TO_LMS.inverse
 /// XYZ color space abstraction.
 protocol XYZColorSpaceRepresentable: WhitePointColorSpace {
 
-    func chromaticAdaptationMatrix(for srcWp: xyY, xyzToLms: matrix_float3x3, lmsToXyz: matrix_float3x3) -> matrix_float3x3
+    func chromaticAdaptationMatrix(
+        for srcWp: xyY,
+        xyzToLms: matrix_float3x3,
+        lmsToXyz: matrix_float3x3
+    ) -> matrix_float3x3
 }
 
 extension XYZColorSpaceRepresentable {
 
-    func chromaticAdaptationMatrix(for srcWp: xyY, xyzToLms: matrix_float3x3 = CAT02_XYZ_TO_LMS, lmsToXyz: matrix_float3x3 = CAT02_LMS_TO_XYZ) -> matrix_float3x3 {
+    func chromaticAdaptationMatrix(
+        for srcWp: xyY,
+        xyzToLms: matrix_float3x3 = CAT02_XYZ_TO_LMS,
+        lmsToXyz: matrix_float3x3 = CAT02_LMS_TO_XYZ
+    ) -> matrix_float3x3 {
         let dstWp = self.whitePoint.chromaticity
         
         let src = xyzToLms * simd_float3(x: srcWp.X, y: srcWp.Y, z: srcWp.Z)
         let dst = xyzToLms * simd_float3(x: dstWp.X, y: dstWp.Y, z: dstWp.Z)
 
-        return lmsToXyz * simd_float3x3(diagonal: SIMD3<Float>(dst.x / src.x, dst.y / src.y, dst.z / src.z)) * xyzToLms
+        return lmsToXyz * simd_float3x3(
+            diagonal: SIMD3<Float>(dst.x / src.x, dst.y / src.y, dst.z / src.z)
+        ) * xyzToLms
     }
 }
 
@@ -144,7 +154,11 @@ public struct XYZ: Color {
     }
 
     private func adaptToM(space: XYZColorSpace, m: matrix_float3x3, mi: matrix_float3x3) -> XYZ {
-        let transform = self.space.chromaticAdaptationMatrix(for: self.space.whitePoint.chromaticity, xyzToLms: m, lmsToXyz: mi)
+        let transform = self.space.chromaticAdaptationMatrix(
+            for: self.space.whitePoint.chromaticity,
+            xyzToLms: m,
+            lmsToXyz: mi
+        )
 
         let v = transform * simd_float3(x: self.x, y: self.y, z: self.z)
 
@@ -169,7 +183,9 @@ extension XYZ {
         let a = 500 * (fx - fy)
         let b = 200 * (fy - fz)
 
-        return LAB(l: l, a: a, b: b, alpha: self.alpha, space: LABColorSpace(whitePoint: xyzColorSpace.whitePoint))
+        let space = LABColorSpace(whitePoint: xyzColorSpace.whitePoint)
+
+        return LAB(l: l, a: a, b: b, alpha: alpha, space: space)
     }
 }
 
@@ -191,7 +207,9 @@ extension XYZ {
         let u = 13.0 * l * (uPrime - uPrimeReference)
         let v = 13.0 * l * (vPrime - vPrimeReference)
 
-        return LUV(l: min(l, 100.0), u: u, v: v, alpha: self.alpha, space: LUVColorSpace(whitePoint: space.whitePoint))
+        let space = LUVColorSpace(whitePoint: space.whitePoint)
+
+        return LUV(l: l, u: u, v: v, alpha: self.alpha, space: space)
     }
 }
 

--- a/Tests/CoreColorTests/LUVTests.swift
+++ b/Tests/CoreColorTests/LUVTests.swift
@@ -64,13 +64,14 @@ class LUVTests: ColorTestCase {
         }
     }
 
+    /// Reference calculator:
+    /// https://calculatorax.com/en/luv-to-hsv
     func test_LUV_to_HSV() throws {
         let luv = LUV(l: 40.00, u: 50.0, v: 60.0, alpha: 1.0, space: LUVColorSpaces.LUV65)
 
         try checkConversion(from: luv) { (src: LUV) -> HSV in
             src.toHSV()
         } check: { hsv, _ in
-            // TODO: Validate these.
             XCTAssertEqual(hsv.h, 36.096985, accuracy: 1e-4)
             XCTAssertEqual(hsv.s, 1.0, accuracy: 1e-4)
             XCTAssertEqual(hsv.v, 0.54064256, accuracy: 1e-4)
@@ -78,13 +79,14 @@ class LUVTests: ColorTestCase {
         }
     }
 
+    /// Reference calculator:
+    /// https://calculatorax.com/en/luv-to-hsl
     func test_LUV_to_HSL() throws {
         let luv = LUV(l: 40.00, u: 50.0, v: 60.0, alpha: 1.0, space: LUVColorSpaces.LUV65)
 
         try checkConversion(from: luv) { (src: LUV) -> HSL in
             src.toHSL()
         } check: { hsl, _ in
-            // TODO: These seem different from other sources.
             XCTAssertEqual(hsl.h, 36.096985, accuracy: 1e-4)
             XCTAssertEqual(hsl.s, 1.0, accuracy: 1e-3)
             XCTAssertEqual(hsl.l, 0.27032128, accuracy: 1e-4)
@@ -98,7 +100,6 @@ class LUVTests: ColorTestCase {
         try checkConversion(from: luv) { (src: LUV) -> CMYK in
             src.toCMYK()
         } check: { cmyk, _ in
-            // TODO: Validate these.
             XCTAssertEqual(cmyk.c, 0.0)
             XCTAssertEqual(cmyk.m, 0.39838356, accuracy: 1e-4)
             XCTAssertEqual(cmyk.y, 1.0, accuracy: 1e-4)

--- a/Tests/CoreColorTests/RGBTests.swift
+++ b/Tests/CoreColorTests/RGBTests.swift
@@ -33,7 +33,51 @@ class RGBTests: ColorTestCase {
         XCTAssertEqual(rgb.blueInt, expected.b)
     }
 
-    func test_RGB_to_HSV() throws {
+    /// Reference calculator:
+    /// https://davengrace.com/cgi-bin/cspace.pl
+    func test_sRGB_to_LinearSRGB() throws {
+        try checkConversion(from: RGB(r: 0.0, g: 0.0, b: 0.0, alpha: 1.0, space: RGBColorSpaces.sRGB)) { (src: RGB) -> RGB in
+            src.toLinearSRGB()
+        } check: { converted, _ in
+            XCTAssertEqual(converted.r, 0.0)
+            XCTAssertEqual(converted.g, 0.0)
+            XCTAssertEqual(converted.b, 0.0)
+            XCTAssertEqual(converted.alpha, 1.0)
+            XCTAssertEqual(converted.space.name, RGBColorSpaces.LinearSRGB.name)
+        }
+
+        try checkConversion(from: RGB(r: 0.18, g: 0.35, b: 0.89, alpha: 1.0, space: RGBColorSpaces.sRGB)) { (src: RGB) -> RGB in
+            src.toLinearSRGB()
+        } check: { converted, _ in
+            XCTAssertEqual(converted.r, 0.027211785, accuracy: 1e-4)
+            XCTAssertEqual(converted.g, 0.10048152, accuracy: 1e-4)
+            XCTAssertEqual(converted.b, 0.7677688, accuracy: 1e-4)
+            XCTAssertEqual(converted.alpha, 1.0)
+            XCTAssertEqual(converted.space.name, RGBColorSpaces.LinearSRGB.name)
+        }
+
+        try checkConversion(from: RGB(r: 0.96, g: 0.83, b: 0.97, alpha: 1.0, space: RGBColorSpaces.sRGB)) { (src: RGB) -> RGB in
+            src.toLinearSRGB()
+        } check: { converted, _ in
+            XCTAssertEqual(converted.r, 0.91140765, accuracy: 1e-4)
+            XCTAssertEqual(converted.g, 0.65593076, accuracy: 1e-4)
+            XCTAssertEqual(converted.b, 0.9331069, accuracy: 1e-4)
+            XCTAssertEqual(converted.alpha, 1.0)
+            XCTAssertEqual(converted.space.name, RGBColorSpaces.LinearSRGB.name)
+        }
+
+        try checkConversion(from: RGB(r: 1.0, g: 1.0, b: 1.0, alpha: 1.0, space: RGBColorSpaces.sRGB)) { (src: RGB) -> RGB in
+            src.toLinearSRGB()
+        } check: { converted, _ in
+            XCTAssertEqual(converted.r, 1.0)
+            XCTAssertEqual(converted.g, 1.0)
+            XCTAssertEqual(converted.b, 1.0)
+            XCTAssertEqual(converted.alpha, 1.0)
+            XCTAssertEqual(converted.space.name, RGBColorSpaces.LinearSRGB.name)
+        }
+    }
+
+    func test_sRGB_to_HSV() throws {
         try check_RGB_to_HSV(rgb: RGB(r: 0.00, g: 0.00, b: 0.00, alpha: 1.0, space: RGBColorSpaces.sRGB),
                              hsv: HSV(h: Float.nan, s: 0.00, v: 0.00, alpha: 1.0))
 
@@ -47,7 +91,7 @@ class RGBTests: ColorTestCase {
                              hsv: HSV(h: Float.nan, s: 0.00, v: 1.00, alpha: 1.0))
     }
 
-    func test_RGB_to_HSL() throws {
+    func test_sRGB_to_HSL() throws {
         try check_RGB_to_HSL(rgb: RGB(r: 0.00, g: 0.00, b: 0.00, alpha: 1.0, space: RGBColorSpaces.sRGB),
                              hsl: HSL(h: Float.nan, s: 0.00, l: 0.00, alpha: 1.0))
 
@@ -61,7 +105,7 @@ class RGBTests: ColorTestCase {
                              hsl: HSL(h: Float.nan, s: 0.00, l: 1.00, alpha: 1.0))
     }
 
-    func test_RGB_to_XYZ() throws {
+    func test_sRGB_to_XYZ() throws {
         try check_RGB_to_XYZ(rgb: RGB(r: 0.00, g: 0.00, b: 0.00, alpha: 1.0, space: RGBColorSpaces.sRGB),
                              xyz: XYZ(x: 0.00, y: 0.00, z: 0.00, alpha: 1.0, space: XYZColorSpaces.XYZ65))
 
@@ -75,7 +119,21 @@ class RGBTests: ColorTestCase {
                              xyz: XYZ(x: 0.95045593, y: 1.0, z: 1.08905775, alpha: 1.0, space: XYZColorSpaces.XYZ65))
     }
 
-    func test_RGB_to_CMYK() throws {
+    func test_LinearSRGB_to_XYZ() throws {
+        try check_RGB_to_XYZ(rgb: RGB(r: 0.00, g: 0.00, b: 0.00, alpha: 1.0, space: RGBColorSpaces.LinearSRGB),
+                             xyz: XYZ(x: 0.00, y: 0.00, z: 0.00, alpha: 1.0, space: XYZColorSpaces.XYZ65))
+
+        try check_RGB_to_XYZ(rgb: RGB(r: 0.18, g: 0.18, b: 0.18, alpha: 1.0, space: RGBColorSpaces.LinearSRGB),
+                             xyz: XYZ(x: 0.1710821, y: 0.18000002, z: 0.1960304, alpha: 1.0, space: XYZColorSpaces.XYZ65))
+
+        try check_RGB_to_XYZ(rgb: RGB(r: 0.40, g: 0.50, b: 0.60, alpha: 1.0, space: RGBColorSpaces.LinearSRGB),
+                             xyz: XYZ(x: 0.45203704, y: 0.4859554, z: 0.637649, alpha: 1.0, space: XYZColorSpaces.XYZ65))
+
+        try check_RGB_to_XYZ(rgb: RGB(r: 1.00, g: 1.00, b: 1.00, alpha: 1.0, space: RGBColorSpaces.LinearSRGB),
+                             xyz: XYZ(x: 0.95045593, y: 1.0, z: 1.08905775, alpha: 1.0, space: XYZColorSpaces.XYZ65))
+    }
+
+    func test_sRGB_to_CMYK() throws {
         try check_RGB_to_CMYK(rgb: RGB(r: 0.00, g: 0.00, b: 0.00, alpha: 1.0, space: RGBColorSpaces.sRGB),
                               cmyk: CMYK(c: 0.00, m: 0.00, y: 0.00, k: 1.00, alpha: 1.00))
 
@@ -89,7 +147,7 @@ class RGBTests: ColorTestCase {
                               cmyk: CMYK(c: 0.00, m: 0.00, y: 0.00, k: 0.00, alpha: 1.00))
     }
 
-    func test_RGB_to_LUV() throws {
+    func test_sRGB_to_LUV() throws {
         try check_RGB_to_LUV(rgb: RGB(r: 0.00, g: 0.00, b: 0.00, alpha: 1.0, space: RGBColorSpaces.sRGB),
                              luv: LUV(l: 0.00, u: 0.00, v: 0.00, alpha: 1.00, space: LUVColorSpaces.LUV65))
 
@@ -103,7 +161,7 @@ class RGBTests: ColorTestCase {
                              luv: LUV(l: 100.00, u: 0.00, v: 0.00, alpha: 1.00, space: LUVColorSpaces.LUV65))
     }
 
-    func test_RGB_to_LAB() throws {
+    func test_sRGB_to_LAB() throws {
         try checkConversion(from: RGB(r: 0.18, g: 0.18, b: 0.18, alpha: 1.0, space: RGBColorSpaces.sRGB)) { (src: RGB) -> LAB in
             src.toLAB()
         } check: { converted, _ in

--- a/Tests/CoreColorTests/RGBTests.swift
+++ b/Tests/CoreColorTests/RGBTests.swift
@@ -119,6 +119,8 @@ class RGBTests: ColorTestCase {
                              xyz: XYZ(x: 0.95045593, y: 1.0, z: 1.08905775, alpha: 1.0, space: XYZColorSpaces.XYZ65))
     }
 
+    /// Reference calculator:
+    /// https://davengrace.com/cgi-bin/cspace.pl
     func test_LinearSRGB_to_XYZ() throws {
         try check_RGB_to_XYZ(rgb: RGB(r: 0.00, g: 0.00, b: 0.00, alpha: 1.0, space: RGBColorSpaces.LinearSRGB),
                              xyz: XYZ(x: 0.00, y: 0.00, z: 0.00, alpha: 1.0, space: XYZColorSpaces.XYZ65))

--- a/Tests/CoreColorTests/XYZTests.swift
+++ b/Tests/CoreColorTests/XYZTests.swift
@@ -24,9 +24,54 @@ class XYZTests: ColorTestCase {
                              rgb: RGB(r: 1.08523261, g: 0.97691161, b: 0.95870753, alpha: 1.0, space: RGBColorSpaces.sRGB))
     }
 
-    func test_XYZ_to_LAB() throws {
+    /// Reference calculator:
+    /// https://www.mathworks.com/help/images/ref/xyz2lab.html
+    func test_XYZ50_to_LAB50() throws {
         try check_XYZ_to_LAB(xyz: XYZ(x: 0.25, y: 0.50, z: 0.75, alpha: 1.0, space: XYZColorSpaces.XYZ50),
                              lab: LAB(l: 76.06926101, a: -78.02949711, b: -34.99756832, alpha: 1.0, space: LABColorSpaces.LAB50))
+
+        try check_XYZ_to_LAB(xyz: XYZ(x: 0.13, y: 0.94, z: 0.68, alpha: 1.0, space: XYZColorSpaces.XYZ50),
+                             lab: LAB(l: 97.63199, a: -100.0, b: 8.404839, alpha: 1.0, space: LABColorSpaces.LAB50))
+
+        try check_XYZ_to_LAB(xyz: XYZ(x: 1.0, y: 1.0, z: 1.0, alpha: 1.0, space: XYZColorSpaces.XYZ50),
+                             lab: LAB(l: 100.0, a: 6.0964227, b: -13.235903, alpha: 1.0, space: LABColorSpaces.LAB50))
+    }
+
+    /// Reference calculator:
+    /// https://www.mathworks.com/help/images/ref/xyz2lab.html
+    func test_XYZ65_to_LAB65() throws {
+        try checkConversion(
+            from: XYZ(x: 0.0, y: 0.0, z: 0.0, alpha: 1.0, space: XYZColorSpaces.XYZ65)
+        ) { (src: XYZ) -> LAB in
+            src.toLAB()
+        } check: { lab, _ in
+            XCTAssertEqual(lab.l, 0.0, accuracy: 1e-4)
+            XCTAssertEqual(lab.a, 0.0, accuracy: 1e-4)
+            XCTAssertEqual(lab.b, 0.0, accuracy: 1e-4)
+            XCTAssertEqual(lab.alpha, 1.0)
+        }
+
+        try checkConversion(
+            from: XYZ(x: 0.25, y: 0.50, z: 0.75, alpha: 1.0, space: XYZColorSpaces.XYZ65)
+        ) { (src: XYZ) -> LAB in
+            src.toLAB()
+        } check: { lab, _ in
+            XCTAssertEqual(lab.l, 76.06926, accuracy: 1e-4)
+            XCTAssertEqual(lab.a, -76.48948, accuracy: 1e-4)
+            XCTAssertEqual(lab.b, -17.877281, accuracy: 1e-4)
+            XCTAssertEqual(lab.alpha, 1.0)
+        }
+
+        try checkConversion(
+            from: XYZ(x: 1.0, y: 1.0, z: 1.0, alpha: 1.0, space: XYZColorSpaces.XYZ65)
+        ) { (src: XYZ) -> LAB in
+            src.toLAB()
+        } check: { lab, _ in
+            XCTAssertEqual(lab.l, 100.0, accuracy: 1e-4)
+            XCTAssertEqual(lab.a, 8.541048, accuracy: 1e-4)
+            XCTAssertEqual(lab.b, 5.6074142, accuracy: 1e-4)
+            XCTAssertEqual(lab.alpha, 1.0)
+        }
     }
 
     func test_XYZ_to_LUV() throws {


### PR DESCRIPTION
This patch introduces a set of small refinements and fixes.

- [API] Introduce method on `Color` that converts to "Linear SRGB" colorspace.
- [API] Make default initializer of `RGB` public.